### PR TITLE
increased information available per package

### DIFF
--- a/pkg/spdx/json/document/document.go
+++ b/pkg/spdx/json/document/document.go
@@ -64,6 +64,8 @@ type Package interface {
 	GetCopyrightText() string
 	GetLicenseConcluded() string
 	GetFilesAnalyzed() bool
+	GetVendorInfo() string
+	GetSourceInfo() string
 	GetLicenseDeclared() string
 	GetVersion() string
 	GetVerificationCode() PackageVerificationCode

--- a/pkg/spdx/json/v2.2/types.go
+++ b/pkg/spdx/json/v2.2/types.go
@@ -99,6 +99,7 @@ type Package struct {
 	Originator           string                   `json:"originator,omitempty"`
 	Supplier             string                   `json:"supplier,omitempty"`
 	SourceInfo           string                   `json:"sourceInfo,omitempty"`
+	VendorInfo           string                   `json:"vendorInfo,omitempty"`
 	CopyrightText        string                   `json:"copyrightText"`
 	HasFiles             []string                 `json:"hasFiles,omitempty"`
 	LicenseInfoFromFiles []string                 `json:"licenseInfoFromFiles,omitempty"`
@@ -117,6 +118,8 @@ func (p *Package) GetLicenseDeclared() string  { return p.LicenseDeclared }
 func (p *Package) GetVersion() string          { return p.Version }
 func (p *Package) GetPrimaryPurpose() string   { return "" }
 func (p *Package) GetSupplier() string         { return p.Supplier }
+func (p *Package) GetVendorInfo() string       { return p.VendorInfo }
+func (p *Package) GetSourceInfo() string       { return p.SourceInfo }
 func (p *Package) GetOriginator() string       { return p.Originator }
 
 func (p *Package) GetVerificationCode() document.PackageVerificationCode {

--- a/pkg/spdx/json/v2.3/types.go
+++ b/pkg/spdx/json/v2.3/types.go
@@ -99,6 +99,7 @@ type Package struct {
 	Originator           string                   `json:"originator,omitempty"`
 	Supplier             string                   `json:"supplier,omitempty"`
 	SourceInfo           string                   `json:"sourceInfo,omitempty"`
+	VendorInfo           string                   `json:"vendorInfo,omitempty"`
 	CopyrightText        string                   `json:"copyrightText"`
 	PrimaryPurpose       string                   `json:"primaryPackagePurpose,omitempty"`
 	HasFiles             []string                 `json:"hasFiles,omitempty"`
@@ -118,6 +119,8 @@ func (p *Package) GetLicenseDeclared() string  { return p.LicenseDeclared }
 func (p *Package) GetVersion() string          { return p.Version }
 func (p *Package) GetPrimaryPurpose() string   { return p.PrimaryPurpose }
 func (p *Package) GetSupplier() string         { return p.Supplier }
+func (p *Package) GetVendorInfo() string       { return p.VendorInfo }
+func (p *Package) GetSourceInfo() string       { return p.SourceInfo }
 func (p *Package) GetOriginator() string       { return p.Originator }
 
 func (p *Package) GetVerificationCode() document.PackageVerificationCode {

--- a/pkg/spdx/package.go
+++ b/pkg/spdx/package.go
@@ -98,6 +98,8 @@ type Package struct {
 	Comment              string   // a place for the SPDX document creator to record any general comments
 	HomePage             string   // A web site that serves as the package home page
 	PrimaryPurpose       string   // Estimate of the most likely package usage
+	VendorInfo           string
+	SourceInfo           string
 
 	// Supplier: the actual distribution source for the package/directory
 	Supplier struct {

--- a/pkg/spdx/parser.go
+++ b/pkg/spdx/parser.go
@@ -251,6 +251,8 @@ func parseJSON(file *os.File) (doc *Document, err error) {
 			LicenseInfoFromFiles: []string{},
 			LicenseDeclared:      pData.GetLicenseDeclared(),
 			Version:              pData.GetVersion(),
+			VendorInfo:           pData.GetVendorInfo(),
+			SourceInfo:           pData.GetSourceInfo(),
 			VerificationCode:     pData.GetVerificationCode().GetValue(),
 			// Comment:              pData.Comment,
 			// HomePage:             pData.HomePage,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds 2 new meta data fields to the package interface: `VendorInfo` and `SourceInfo` . These are required for my use case of the `todot` feature I am working on as part of #530

#### Which issue(s) this PR fixes:

None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
